### PR TITLE
Add emoji labels

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -15,9 +15,10 @@ global.requestAnimationFrame = () => {};
 const ctx = {
   save(){}, restore(){}, clearRect(){}, translate(){}, rotate(){},
   beginPath(){}, moveTo(){}, lineTo(){}, arc(){}, closePath(){},
-  fill(){}, stroke(){},
+  fill(){}, stroke(){}, fillText(){},
   set lineWidth(v){}, set lineCap(v){}, set strokeStyle(v){},
-  set fillStyle(v){}, set globalAlpha(v){},
+  set fillStyle(v){}, set globalAlpha(v){}, set font(v){},
+  set textAlign(v){}, set textBaseline(v){},
 };
 
 global.document = {

--- a/webos-app/script.js
+++ b/webos-app/script.js
@@ -111,6 +111,19 @@ function drawClock(sections) {
         ctx.strokeStyle = '#fff';
         ctx.stroke();
       }
+
+      // draw emoji label near the outer edge of the section
+      const mid = (startAngle + endAngle) / 2;
+      const emojiRadius = radius * 0.85;
+      const x = center + Math.cos(mid) * emojiRadius;
+      const y = center + Math.sin(mid) * emojiRadius;
+      ctx.save();
+      ctx.font = `${radius * 0.2}px sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = '#000';
+      ctx.fillText(s.name, x, y);
+      ctx.restore();
     });
 
     ctx.globalAlpha = 1;


### PR DESCRIPTION
## Summary
- draw emoji labels for each schedule section
- stub canvas text API in test runner

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688cd7e1c0f08326b79aca086c67d040