### PR TITLE
Add Docker deployment for HTML version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: serve package clean test
+.PHONY: serve package clean test install run
 
 serve:
 	python3 -m http.server -d webos-app 8000
@@ -11,3 +11,10 @@ clean:
 
 test:
 	node test/test.js
+
+install:
+	apt-get update
+	apt-get install -y docker.io docker-compose-plugin
+
+run:
+	docker compose up

--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ You can use the Makefile for common tasks:
 - `make clean` – remove the generated archive.
 - `make test` – run a simple Node.js check to ensure the app loads without
   ReferenceErrors.
+
+## Docker deployment
+
+To host the HTML version with nginx on Ubuntu:
+
+- `make install` – install Docker and the Docker Compose plugin.
+- `make run` – start the nginx container serving `webos-app` on port 80.
+
+Point the `facelesscat.wtf` domain at the machine running the container to
+access the app in a browser.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./webos-app:/usr/share/nginx/html:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name facelesscat.wtf;
+    root /usr/share/nginx/html;
+    index index.html;
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}


### PR DESCRIPTION
## Summary
- add Docker compose and nginx config to serve the webOS app as plain HTML
- extend Makefile with install/run targets for Docker setup
- document Docker-based deployment in README

## Testing
- `make test`
- `make install` *(fails: The repository ... InRelease is not signed)*
- `make run` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cae3cebe4832680f03b577eb593ee